### PR TITLE
Fix ScrollView layoutSubviews to respect contentOffset

### DIFF
--- a/Sources/TermKit/Views/ScrollView.swift
+++ b/Sources/TermKit/Views/ScrollView.swift
@@ -296,10 +296,10 @@ open class ScrollView : View {
         let f = bounds
         
         contentView.frame = Rect(
-            x: f.minX,
-            y: f.minY,
-            width: f.width-(_showsVerticalScrollIndicator ? 1 : 0),
-            height: f.height-(_showsHorizontalScrollIndicator ? 1 : 0))
+            x: _contentOffset.x,
+            y: _contentOffset.y,
+            width: max(f.width-(_showsVerticalScrollIndicator ? 1 : 0), contentSize.width),
+            height: max(f.height-(_showsHorizontalScrollIndicator ? 1 : 0), contentSize.height))
         try? contentView.layoutSubviews()
         if _showsVerticalScrollIndicator {
             vertical.frame = Rect (


### PR DESCRIPTION
Fixes a bug where ScrollView's contentView frame origin is reset to 0, 0 during layoutSubviews, which prevents the context from scrolling. Also ensures the contentView sizes correctly using the max of the view frame and the content size.